### PR TITLE
Fehlermeldung bei deaktiviertem JavaScript

### DIFF
--- a/formgroups/resourceInformation.html
+++ b/formgroups/resourceInformation.html
@@ -1,4 +1,10 @@
 <main class="container-fluid my-3 pb-5">
+  <!-- Hinweis bei deaktiviertem JavaScript-->
+  <noscript>
+    <div class="alert alert-danger text-center">
+      JavaScript is disabled. Please enable JavaScript to use this form.
+    </div>
+  </noscript>
   <div class="alert alert-info p-2">
     <div class="row">
       <div class="col-11 text-center">Please fill out the form in english.</div>

--- a/formgroups/resourceInformation.html
+++ b/formgroups/resourceInformation.html
@@ -2,7 +2,7 @@
   <!-- Hinweis bei deaktiviertem JavaScript-->
   <noscript>
     <div class="alert alert-danger text-center">
-      JavaScript is disabled. Please enable JavaScript to use this form.
+      <?php echo $translations['no_javascript_alert']; ?>
     </div>
   </noscript>
   <div class="alert alert-info p-2">

--- a/lang/de.php
+++ b/lang/de.php
@@ -10,6 +10,7 @@ $translations = [
     'affiliation' => 'Zugehörigkeit(en)',
     'role_label' => 'Rolle(n)',
     'add' => '+',
+    'no_javascript_alert' => 'JavaScript ist deaktiviert. Bitte aktivieren Sie JavaScript, um dieses Formular zu verwenden.',
 
     // Form Group Resource Information
     'resourceInformation' => 'Informationen zur Ressource',

--- a/lang/en.php
+++ b/lang/en.php
@@ -10,6 +10,7 @@ $translations = [
     'affiliation' => 'Affiliation(s)',
     'role_label' => 'Role(s)',
     'add' => '+',
+    'no_javascript_alert' => 'JavaScript is disabled. Please enable JavaScript to use this form.',
 
     // Form Group Resource Information
     'resourceInformation' => 'Resource Information',

--- a/lang/fr.php
+++ b/lang/fr.php
@@ -2,7 +2,7 @@
 ///////////////////////////////////////////////////////////////////
 // Description: French language file for the metadata editor     //
 // Authors: Matan Israel, Holger Ehrmann                         //
-// Version: 1.7                                                  //
+// Version: 1.8                                                  //
 // License: CC BY 4.0                                            //
 ///////////////////////////////////////////////////////////////////
 
@@ -17,6 +17,7 @@ $translations = [
     'affiliation' => 'Affiliation(s)',
     'role_label' => 'Rôle(s)',
     'add' => '+',
+    'no_javascript_alert' => 'JavaScript est désactivé. Veuillez activer JavaScript pour utiliser ce formulaire.',
 
     // Groupe de formulaire Informations sur la ressource
     'resourceInformation' => 'Informations sur la ressource',


### PR DESCRIPTION
Warnhinweis bei deaktiviertem JavaScript implementiert:
- Verwendung des noscript-Elements aus HTML5 zur Anzeige eines Warnhinweises, wenn Nutzende JavaScript im Browser aktiv unterdrücken oder in den Einstellungen deaktiviert haben.
- Übersetzung des Warnhinweises in alle drei aktuell verfügbaren Sprachdateien
- Fixed #110 