### PR TITLE
Bugfixes Sprint 3

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,14 +1,16 @@
 <IfModule mod_rewrite.c>
+    # Enable the RewriteEngine module, which allows URL rewriting
     RewriteEngine On
-    RewriteBase /mde-msl/
 
-    # Wenn die Datei oder das Verzeichnis nicht existiert, leite weiter
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
+    # If the requested filename exists as a file (-f) or directory (-d), skip the next rule
+    RewriteCond %{REQUEST_FILENAME} -f [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^ - [L]
 
-    # Für API-Anfragen
+    # For API requests: rewrite URLs starting with 'api/' to 'api/index.php'
     RewriteRule ^api/(.*)$ api/index.php [QSA,L]
 
-    # Für alle anderen Anfragen (falls nötig)
+    # For all other requests (if needed), rewrite to 'index.php'
+    # Uncomment the following line if you want all other routes to point to 'index.php'
     # RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Dieser Metadaten-Editor entstand im Rahmen eines studentischen Kooperationsproje
 3. Apache und MySQL starten nicht vergessen.
 4. Datenbank "mde" in MySQL (z. B. mittels phpMyAdmin) erstellen.
 5. Inhalt der Datei sample_settings.php in neue Datei `settings.php` kopieren und Einstellungen für Datenbankverbindung anpassen.
-6. Für die automatisch generierten Zeitzonen-Auswahl einen kostenlosen API Key unter https://timezonedb.com/ erstellen und ebenfalls in der neu erstellen settings.php eintragen
-7. Google Maps JS API Key erstellen und ebenfalls in die Datei settings.php einfügen.
-8. Alle Dateien dieses Repositories in den Ordner "htdocs"-Ordner des Webservers kopieren.
-9. install.php über den Browser aufrufen. Die Datenbank-Tabellen werden automatisch erstellt.
-10. Der Metadateneditor ist nun über localhost/verzeichnisname im Browser erreichbar.
+6. Pfad /mde-msl/ in Datei `.htaccess` anpassen an eigenen Installationspfad. Sollte die Anwendung im Hauptverzeichnis installiert werden, reicht der Schrägstrich ("/").
+7. Für die automatisch generierten Zeitzonen-Auswahl einen kostenlosen API Key unter https://timezonedb.com/ erstellen und ebenfalls in der neu erstellen settings.php eintragen
+8. Google Maps JS API Key erstellen und ebenfalls in die Datei settings.php einfügen.
+9. Alle Dateien dieses Repositories in den Ordner "htdocs"-Ordner des Webservers kopieren.
+10. install.php über den Browser aufrufen. Die Datenbank-Tabellen werden automatisch erstellt.
+11. Der Metadateneditor ist nun über localhost/verzeichnisname im Browser erreichbar.
 
 Bei Problemen mit der Installation, hinterlasse gerne einen Eintrag im Issue Board dieses Repositories!
 

--- a/api/v2/docs/swagger.yaml
+++ b/api/v2/docs/swagger.yaml
@@ -13,7 +13,7 @@ info:
   license:
     name: MIT
     url: https://raw.githubusercontent.com/McNamara84/gfz-metadata-editor-msl-v2/refs/heads/main/LICENSE.md
-  version: 1.7.0
+  version: 1.8.0
 externalDocs:
   description: Documentation of the API V1 at GitHub
   url: https://github.com/McNamara84/gfz-metadata-editor-msl-v2#api-endpunkte

--- a/api/v2/index.php
+++ b/api/v2/index.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Entry point for API version 2.
+ *
+ * This script initializes the routing for the API, processes incoming HTTP requests,
+ * and dispatches them to the appropriate controllers based on the URI and HTTP method.
+ */
+
+// Define the API version.
+$version = 'v2'; // Add this line to define the version.
+
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/controllers/GeneralController.php';
 require_once __DIR__ . '/controllers/VocabController.php';
@@ -8,58 +18,111 @@ require_once __DIR__ . '/controllers/ValidationController.php';
 use FastRoute\Dispatcher;
 use FastRoute\RouteCollector;
 
+/**
+ * Load the API routes from the routes configuration file.
+ *
+ * @var array $routes An array of routes defined for the API.
+ */
 $routes = require __DIR__ . '/routes/api.php';
 
+/**
+ * Initialize the FastRoute dispatcher with the loaded routes.
+ *
+ * @var Dispatcher $dispatcher The dispatcher responsible for routing requests.
+ */
 $dispatcher = FastRoute\simpleDispatcher(function (RouteCollector $r) use ($routes) {
     foreach ($routes as $route) {
         $r->addRoute($route[0], $route[1], $route[2]);
     }
 });
 
+/**
+ * Retrieve the HTTP method and URI from the server variables.
+ *
+ * @var string $httpMethod The HTTP method of the request (e.g., GET, POST).
+ * @var string $uri        The request URI.
+ */
 $httpMethod = $_SERVER['REQUEST_METHOD'];
 $uri = $_SERVER['REQUEST_URI'];
 
-// Debug logging
+// Debug logging: Log the original URI.
 error_log("Original URI: " . $uri);
 
-// Strip query string (?foo=bar) and decode URI
+/**
+ * Strip the query string from the URI and decode it.
+ */
 if (false !== $pos = strpos($uri, '?')) {
     $uri = substr($uri, 0, $pos);
 }
 $uri = rawurldecode($uri);
 
-// Vereinfachte URI-Verarbeitung
-if (preg_match('#^/mde-msl/api/v2(.*)#', $uri, $matches)) {
-    // Lokale Entwicklungsumgebung
-    $uri = $matches[1];
-} elseif (preg_match('#^/api/v2(.*)#', $uri, $matches)) {
-    // Produktionsserver
-    $uri = $matches[1];
+/**
+ * Dynamically determine the base path of the script.
+ *
+ * @var string $scriptName The script name from the server variables.
+ * @var string $scriptDir  The directory of the script, normalized to use forward slashes.
+ */
+$scriptName = $_SERVER['SCRIPT_NAME']; // e.g., /mde-msl/api/index.php
+$scriptDir = str_replace('\\', '/', dirname($scriptName)); // e.g., /mde-msl/api
+
+/**
+ * Append the API version to the base path.
+ */
+$scriptDir .= '/' . $version; // Now $scriptDir is e.g., /mde-msl/api/v2
+
+/**
+ * Remove the base path from the URI to get the relative path.
+ */
+if (substr($uri, 0, strlen($scriptDir)) === $scriptDir) {
+    $uri = substr($uri, strlen($scriptDir));
 }
 
-// Ensure the URI starts with a /
+/**
+ * Ensure that the URI starts with a '/'.
+ */
 if (empty($uri) || $uri[0] !== '/') {
     $uri = '/' . $uri;
 }
 
+// Debug logging: Log the processed URI.
 error_log("Processed URI: " . $uri);
 
+/**
+ * Dispatch the request to the appropriate route handler.
+ *
+ * @var array $routeInfo Information about the matched route.
+ */
 $routeInfo = $dispatcher->dispatch($httpMethod, $uri);
+
 switch ($routeInfo[0]) {
     case Dispatcher::NOT_FOUND:
+        /**
+         * Handle the case where no matching route was found.
+         */
         http_response_code(404);
         echo json_encode(['error' => 'Not Found']);
         break;
     case Dispatcher::METHOD_NOT_ALLOWED:
+        /**
+         * Handle the case where the HTTP method is not allowed for the matched route.
+         */
         http_response_code(405);
         echo json_encode(['error' => 'Method Not Allowed']);
         break;
     case Dispatcher::FOUND:
+        /**
+         * Handle the case where a matching route was found.
+         *
+         * @var mixed $handler The handler for the route, which can be a callable or an array specifying a controller and method.
+         * @var array $vars    The variables extracted from the URI.
+         */
         $handler = $routeInfo[1];
         $vars = $routeInfo[2];
         if (is_array($handler) && is_object($handler[0])) {
+            // If the handler is an array with a controller object and method name.
             $handler[0]->{$handler[1]}($vars);
         } else {
+            // If the handler is a callable function.
             call_user_func($handler, $vars);
         }
         break;

--- a/doc/help.html
+++ b/doc/help.html
@@ -30,17 +30,11 @@
                 <ul class="nav nav-pills flex-column">
                     <li class="nav-item"><a class="nav-link active" href="#introduction">Introduction</a></li>
                     <li class="nav-item"><a class="nav-link" href="#resource-information">Resource Information</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#doi">DOI</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#publication-year">Publication Year</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#resource-type">Resource Type</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#version">Version</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#language-of-dataset">Language of dataset</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#title">Title</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#title-type">Title Type</a></li>
                     <li class="nav-item"><a class="nav-link" href="#authors">Authors</a></li>
                     <li class="nav-item"><a class="nav-link" href="#licenses-rights">Licenses and rights</a></li>
                     <li class="nav-item"><a class="nav-link" href="#contact-persons">Contact Persons</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#originatingLaboratory">Originating Laboratory</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#originatingLaboratory">Originating Laboratory</a>
+                    </li>
                     <li class="nav-item"><a class="nav-link" href="#contributors">Contributors</a></li>
                     <li class="nav-item"><a class="nav-link" href="#descriptions">Descriptions</a></li>
                     <li class="nav-item"><a class="nav-link" href="#mslkeywords">MSL-Keywords</a></li>
@@ -50,7 +44,7 @@
                     <li class="nav-item"><a class="nav-link" href="#dates">Dates</a></li>
                     <li class="nav-item"><a class="nav-link" href="#relatedWork">Related Work</a></li>
                     <li class="nav-item"><a class="nav-link" href="#funding_reference">Funding Reference</a></li>
-                  
+
                     <!-- Hier neue Sections hinzufügen -->
                 </ul>
             </nav>
@@ -74,131 +68,152 @@
                         dataset, Title and Title Type. Up to
                         <?php echo $maxTitles; ?> different titles can be specified.
                     </p>
+                    <div id="doi">
+                        <h3>DOI</h3>
+                        <p>The DOI is a unique string that identifies a resource. Format should be 10.ORGANISATION/ID.
+                            If
+                            you
+                            have no DOI for your dataset yet, you can leave this field empty.</p>
+                    </div>
+                    <!-- Inhalt aus Section 4 -->
+                    <div id="publication-year">
+                        <h3>Publication Year</h3>
+                        <p>The year when the data was or will be made publicly available. In the case of datasets,
+                            “publish”
+                            is understood to mean making the data available on a specific date to the community of
+                            researchers.</p>
+                        <ul>
+                            <li>If that date cannot be determined, use the date of registration.</li>
+                            <li>If an embargo period has been in effect, use the date when the embargo period ends.</li>
+                            <li>If there is no standard publication year value, use the date that would be preferred
+                                from a
+                                citation perspective.</li>
+                        </ul>
+                    </div>
+                    <!-- Inhalt aus Section 5 -->
+                    <div id="resource-type">
+                        <h3>Resource Type</h3>
+                        <p>The data record is classified in the Resource Type form field. The following different
+                            resource
+                            types are available for selection.</p>
+                        <ul>
+                            <li><strong>Audiovisual:</strong> A series of visual representations that, when shown in
+                                sequence, give
+                                the impression of movement. May or may not include sound.</li>
+                            <li><strong>Book:</strong> A non-serial publication that is complete in one volume or a
+                                designated
+                                finite number of volumes.</li>
+                            <li><strong>BookChapter:</strong> A defined chapter or section of a book.</li>
+                            <li><strong>Collection:</strong> An aggregation of resources, which can be any aggregation
+                                of
+                                resources
+                                such as datasets, documents, etc.</li>
+                            <li><strong>ComputationalNotebook:</strong> An interactive document containing code, data,
+                                and
+                                text that
+                                is used for conducting and documenting computational research.</li>
+                            <li><strong>ConferencePaper:</strong> A paper that was presented at a conference.</li>
+                            <li><strong>ConferenceProceeding:</strong> A collection of papers presented at a conference.
+                            </li>
+                            <li><strong>DataPaper:</strong> A scholarly publication describing a dataset, published in a
+                                data
+                                journal.</li>
+                            <li><strong>Dataset:</strong> A structured collection of data generally associated with a
+                                unique
+                                body of
+                                work.</li>
+                            <li><strong>Dissertation:</strong> A formal and lengthy discourse or treatise on a
+                                particular
+                                subject,
+                                based on original research, and submitted for an academic degree.</li>
+                            <li><strong>Event:</strong> A non-persistent, time-based occurrence.</li>
+                            <li><strong>Image:</strong> A visual representation other than text.</li>
+                            <li><strong>Instrument:</strong> A device or tool used for scientific purposes.</li>
+                            <li><strong>InteractiveResource:</strong> A resource that requires interaction from the user
+                                to
+                                be
+                                understood, executed, or experienced.</li>
+                            <li><strong>Journal:</strong> A periodic publication that contains articles on current
+                                research,
+                                usually
+                                published in issues and volumes.</li>
+                            <li><strong>JournalArticle:</strong> A publication in a journal.</li>
+                            <li><strong>Model:</strong> An abstract, conceptual, graphical, or mathematical
+                                representation
+                                of
+                                processes or entities.</li>
+                            <li><strong>OutputManagementPlan:</strong> A document describing data outputs, management
+                                and
+                                sharing
+                                practices, and policies.</li>
+                            <li><strong>PeerReview:</strong> A review of a resource that has been conducted by experts
+                                in
+                                the field.
+                            </li>
+                            <li><strong>PhysicalObject:</strong> An inanimate, three-dimensional object or substance.
+                            </li>
+                            <li><strong>Preprint:</strong> A version of a scholarly or scientific paper that precedes
+                                formal
+                                peer
+                                review and publication in a peer-reviewed scholarly or scientific journal.</li>
+                            <li><strong>Report:</strong> A formal account of an investigation, research, or event.</li>
+                            <li><strong>Service:</strong> A system that provides one or more functions to users, such as
+                                a
+                                web
+                                service.</li>
+                            <li><strong>Software:</strong> A computer program in source or compiled form.</li>
+                            <li><strong>Sound:</strong> A resource primarily intended to be heard.</li>
+                        </ul>
+                    </div>
+                    <!-- Inhalt aus Section 6 -->
+                    <div id="version">
+                        <h3>Version</h3>
+                        <p>The version number or other identifier of the dataset. If your dataset is published for the
+                            first
+                            time, this field can be left empty. If it has been updated, specify the version number here.
+                            The
+                            suggested practice is to use a pair of <em>major_version.minor_version</em> to indicate
+                            changes
+                            in the dataset. Major changes typically require registration of a new DOI. <em>If unsure
+                                leave
+                                blank.</em></p>
+                    </div>
+                    <!-- Inhalt aus Section 7 -->
+                    <div id="language-of-dataset">
+                        <h3>Language of dataset</h3>
+                        <p>The primary language of the dataset. Choose from a list of supported languages. Default is
+                            English.</p>
+                    </div>
+                    <!-- Inhalt aus Section 8 -->
+                    <div id="title">
+                        <h3>Title</h3>
+                        <p>The main title of the dataset. You can specify up to
+                            <?php echo $maxTitles; ?> different title types if your dataset
+                            is known by multiple names or translations.
+                        </p>
+                    </div>
+                    <!-- Inhalt aus Section 9 -->
+                    <div id="title-type">
+                        <h3>Title Type</h3>
+                        <p>Indicates the type of title being provided, such as an alternative title or translated title.
+                            Default is "MainTitle". Every title should have a title type.</p>
+                        <ul>
+                            <li><strong>Main Title:</strong> The primary title by which the dataset is known. This title
+                                type is
+                                required.</li>
+                            <li><strong>Alternative Title:</strong> You can also add an alternative title if required.
+                            </li>
+                            <li><strong>Subtitle:</strong> If the data record has a subtitle, you can enter it with this
+                                title type.
+                            </li>
+                            <li><strong>Translated Title:</strong> If the dataset is also to be published with a
+                                translated
+                                title,
+                                this title should have this title type.</li>
+                        </ul>
+                    </div>
                 </div>
                 <div class="section-divider"></div>
-                <!-- Inhalt aus Section 3 -->
-                <div id="doi">
-                    <h3>DOI</h3>
-                    <p>The DOI is a unique string that identifies a resource. Format should be 10.ORGANISATION/ID. If
-                        you
-                        have no DOI for your dataset yet, you can leave this field empty.</p>
-                </div>
-                <div class="section-divider"></div>
-                <!-- Inhalt aus Section 4 -->
-                <div id="publication-year">
-                    <h3>Publication Year</h3>
-                    <p>The year in which the data were or will be made publicly available. If an embargo period was in
-                        effect, use the date when the embargo period ended. In the case of datasets, 'release' means
-                        making the data available to the research community on a specific date. If there is no standard
-                        value for the year of
-                        publication, use the date that would be preferred from a citation perspective.</p>
-                </div>
-                <div class="section-divider"></div>
-                <!-- Inhalt aus Section 5 -->
-                <div id="resource-type">
-                    <h3>Resource Type</h3>
-                    <p>The data record is classified in the Resource Type form field. The following different resource
-                        types are available for selection.</p>
-                    <ul>
-                        <li><strong>Audiovisual:</strong> A series of visual representations that, when shown in
-                            sequence, give
-                            the impression of movement. May or may not include sound.</li>
-                        <li><strong>Book:</strong> A non-serial publication that is complete in one volume or a
-                            designated
-                            finite number of volumes.</li>
-                        <li><strong>BookChapter:</strong> A defined chapter or section of a book.</li>
-                        <li><strong>Collection:</strong> An aggregation of resources, which can be any aggregation of
-                            resources
-                            such as datasets, documents, etc.</li>
-                        <li><strong>ComputationalNotebook:</strong> An interactive document containing code, data, and
-                            text that
-                            is used for conducting and documenting computational research.</li>
-                        <li><strong>ConferencePaper:</strong> A paper that was presented at a conference.</li>
-                        <li><strong>ConferenceProceeding:</strong> A collection of papers presented at a conference.
-                        </li>
-                        <li><strong>DataPaper:</strong> A scholarly publication describing a dataset, published in a
-                            data
-                            journal.</li>
-                        <li><strong>Dataset:</strong> A structured collection of data generally associated with a unique
-                            body of
-                            work.</li>
-                        <li><strong>Dissertation:</strong> A formal and lengthy discourse or treatise on a particular
-                            subject,
-                            based on original research, and submitted for an academic degree.</li>
-                        <li><strong>Event:</strong> A non-persistent, time-based occurrence.</li>
-                        <li><strong>Image:</strong> A visual representation other than text.</li>
-                        <li><strong>Instrument:</strong> A device or tool used for scientific purposes.</li>
-                        <li><strong>InteractiveResource:</strong> A resource that requires interaction from the user to
-                            be
-                            understood, executed, or experienced.</li>
-                        <li><strong>Journal:</strong> A periodic publication that contains articles on current research,
-                            usually
-                            published in issues and volumes.</li>
-                        <li><strong>JournalArticle:</strong> A publication in a journal.</li>
-                        <li><strong>Model:</strong> An abstract, conceptual, graphical, or mathematical representation
-                            of
-                            processes or entities.</li>
-                        <li><strong>OutputManagementPlan:</strong> A document describing data outputs, management and
-                            sharing
-                            practices, and policies.</li>
-                        <li><strong>PeerReview:</strong> A review of a resource that has been conducted by experts in
-                            the field.
-                        </li>
-                        <li><strong>PhysicalObject:</strong> An inanimate, three-dimensional object or substance.</li>
-                        <li><strong>Preprint:</strong> A version of a scholarly or scientific paper that precedes formal
-                            peer
-                            review and publication in a peer-reviewed scholarly or scientific journal.</li>
-                        <li><strong>Report:</strong> A formal account of an investigation, research, or event.</li>
-                        <li><strong>Service:</strong> A system that provides one or more functions to users, such as a
-                            web
-                            service.</li>
-                        <li><strong>Software:</strong> A computer program in source or compiled form.</li>
-                        <li><strong>Sound:</strong> A resource primarily intended to be heard.</li>
-                    </ul>
-                </div>
-                <!-- Inhalt aus Section 6 -->
-                <div id="version">
-                    <h3>Version</h3>
-                    <p>The version number or other identifier of the dataset. If your dataset is published for the first
-                        time, this field can be left empty. If it has been updated, specify the version number here. The
-                        suggested practice is to use a pair of <em>major_version.minor_version</em> to indicate changes
-                        in the dataset. Major changes typically require registration of a new DOI. <em>If unsure leave
-                            blank.</em></p>
-                </div>
-                <div class="section-divider"></div>
-                <!-- Inhalt aus Section 7 -->
-                <div id="language-of-dataset">
-                    <h3>Language of dataset</h3>
-                    <p>The primary language of the dataset. Choose from a list of supported languages. Default is
-                        English.</p>
-                </div>
-                <div class="section-divider"></div>
-                <!-- Inhalt aus Section 8 -->
-                <div id="title">
-                    <h3>Title</h3>
-                    <p>The main title of the dataset. You can specify up to
-                        <?php echo $maxTitles; ?> different title types if your dataset
-                        is known by multiple names or translations.
-                    </p>
-                </div>
-                <!-- Inhalt aus Section 9 -->
-                <div id="title-type">
-                    <h3>Title Type</h3>
-                    <p>Indicates the type of title being provided, such as an alternative title or translated title.
-                        Default is "MainTitle". Every title should have a title type.</p>
-                    <ul>
-                        <li><strong>Main Title:</strong> The primary title by which the dataset is known. This title
-                            type is
-                            required.</li>
-                        <li><strong>Alternative Title:</strong> You can also add an alternative title if required.</li>
-                        <li><strong>Subtitle:</strong> If the data record has a subtitle, you can enter it with this
-                            title type.
-                        </li>
-                        <li><strong>Translated Title:</strong> If the dataset is also to be published with a translated
-                            title,
-                            this title should have this title type.</li>
-                    </ul>
-                </div>
                 <!-- Inhalt aus Section -->
                 <div id="licenses-rights">
                     <h2>Licenses and rights</h2>
@@ -222,7 +237,8 @@
                     <div id="affiliation">
                         <h3>Affiliation</h3>
                         <p>The organisational or institutional affiliation of the creator.</p>
-                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not among the available options, it can be entered manually.</p>
+                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not
+                            among the available options, it can be entered manually.</p>
                     </div>
                     <div class="section-divider"></div>
                     <div id="addAffiliationInfo">
@@ -230,6 +246,7 @@
                         <p>Specify the Affiliation Information. You can enter the section, department or group here.</p>
                     </div>
                 </div>
+                <div class="section-divider"></div>
                 <div id="contact-persons">
                     <h2>Contact Persons</h2>
                     <div id="position">
@@ -245,24 +262,30 @@
                     <div id="CP_affiliation">
                         <h3>Affiliation</h3>
                         <p>The organisational or institutional affiliation of the Person.</p>
-                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not among the available options, it can be entered manually.</p>
+                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not
+                            among the available options, it can be entered manually.</p>
                     </div>
                     <div class="section-divider"></div>
                 </div>
+                <div class="section-divider"></div>
                 <div id="originatingLaboratory">
                     <h2>Originating Laboratory</h2>
                     <div id="LaboratorynameHelp">
                         <h3>Name of the originating laboratory</h3>
-                        <p>It is recommended that the laboratory be selected from the list, as the affiliation is populated by the autocomplete function. In the event that the desired laboratory is not among the available options, it can be entered manually.</p>
+                        <p>It is recommended that the laboratory be selected from the list, as the affiliation is
+                            populated by the autocomplete function. In the event that the desired laboratory is not
+                            among the available options, it can be entered manually.</p>
                         <p>The list opens when you start typing.</p>
                     </div>
                     <div id="LaboratoryAffiliationHelp">
                         <h3>Affiliation of the originating laboratory</h3>
                         <p>The organisational or institutional affiliation of the laboratory.</p>
-                        <p>It is recommended to select the affiliation from the list, if the required laboratory-Affiliation is not among the available options, it can be entered manually.</p>
+                        <p>It is recommended to select the affiliation from the list, if the required
+                            laboratory-Affiliation is not among the available options, it can be entered manually.</p>
                         <p>The list opens when you start typing.</p>
                     </div>
-                </div> 
+                </div>
+                <div class="section-divider"></div>
                 <div id="contributors">
                     <h2>Contributors</h2>
                     <div id="CPer_roles">
@@ -281,7 +304,8 @@
                     <div id="CPer_affiliation">
                         <h3>Affiliation</h3>
                         <p>The organisational or institutional affiliation of the Person/s.</p>
-                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not among the available options, it can be entered manually.</p>
+                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not
+                            among the available options, it can be entered manually.</p>
                     </div>
                     <div class="section-divider"></div>
                     <div class="section-divider"></div>
@@ -298,10 +322,12 @@
                     <div id="cOrg_affiliation">
                         <h3>Affiliation</h3>
                         <p>The organisational or institutional affiliation of the Institution.</p>
-                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not among the available options, it can be entered manually.</p>
+                        <p>It is recommended to select the affiliation from the list, if the required affiliation is not
+                            among the available options, it can be entered manually.</p>
                     </div>
                     <div class="section-divider"></div>
                 </div>
+                <div class="section-divider"></div>
                 <div id="descriptions">
                     <h2>Descriptions</h2>
                     <div id="abstract">
@@ -327,22 +353,28 @@
                     </div>
                     <div class="section-divider"></div>
                 </div>
+                <div class="section-divider"></div>
                 <div id="mslkeywords">
                     <h2>MSL Keywords</h2>
                     <div id="mslkeywords">
-                        <p>Please click on the Thesaurus button to the right to select keywords from the thesaurus or start typing to use the autocomplete function.
-                            <div class="section-divider"></div>
-                            The selectable keywords are taken from the repository of the <a target="_blank" href="https://github.com/UtrechtUniversity/msl_vocabularies">MSL vocabularies</a>.
+                        <p>Please click on the Thesaurus button to the right to select keywords from the thesaurus or
+                            start typing to use the autocomplete function.
+                        <div class="section-divider"></div>
+                        The selectable keywords are taken from the repository of the <a target="_blank"
+                            href="https://github.com/UtrechtUniversity/msl_vocabularies">MSL vocabularies</a>.
                         </p>
                     </div>
                 </div>
+                <div class="section-divider"></div>
                 <div id="thesaurus">
                     <h2>Thesaurus Keywords</h2>
                     <div id="thesKeywords">
                         <!-- Feld der Form Group Thesaurus Keywords wird hier erklärt -->
                         <p>Please click on the Thesaurus button to the right to select keywords from the thesaurus
                             or start typing to use the autocomplete function. </p>
-                        <p>Thesaurus keywords are essential for filtering options within the GFZ Metadata Portal. Therefore, we highly recommend selecting at least one GCMD Science Keyword to describe your dataset (you are welcome to add more if relevant).</p>
+                        <p>Thesaurus keywords are essential for filtering options within the GFZ Metadata Portal.
+                            Therefore, we highly recommend selecting at least one GCMD Science Keyword to describe your
+                            dataset (you are welcome to add more if relevant).</p>
                     </div>
                     <div id="modalHelp">
                         <h3>Keyword Viewer</h3>
@@ -358,13 +390,17 @@
                             descriptions.</p>
                     </div>
                 </div>
+                <div class="section-divider"></div>
                 <!-- Feld Free Keywords wird erklärt -->
                 <div id="freeKeywords">
-                     <h3>Free Keywords</h3>
-                     <p>Free keywords are user-defined tags that complement predefined thesaurus terms. 
-                       They allow for individual description and categorization of your content and improve its discoverability. 
-                       Before adding a free keyword, please check if a suitable term already exists in one of the thesauri above.</p>
+                    <h3>Free Keywords</h3>
+                    <p>Free keywords are user-defined tags that complement predefined thesaurus terms.
+                        They allow for individual description and categorization of your content and improve its
+                        discoverability.
+                        Before adding a free keyword, please check if a suitable term already exists in one of the
+                        thesauri above.</p>
                 </div>
+                <div class="section-divider"></div>
                 <div id="tsc">
                     <h2>Spatial and temporal coverage</h2>
                     <div id="geographical-coverage">
@@ -403,11 +439,13 @@
                         </ul>
                     </div>
                 </div>
+                <div class="section-divider"></div>
                 <div id="tsc-description">
                     <h3>Description</h3>
                     Free text field for explaining the geographic and temporal
                     context. Required field without any restrictions.
                 </div>
+                <div class="section-divider"></div>
                 <div id="tsc-temporal">
                     <h3>Temporal Coverage</h3>
                     <ul>
@@ -423,6 +461,7 @@
                             All worldwide time zones can be selected. Required field.</li>
                     </ul>
                 </div>
+                <div class="section-divider"></div>
                 <div id="dates">
                     <h2>Dates</h2>
                     <div id="date-created">
@@ -439,27 +478,13 @@
                             this field empty.</p>
                     </div>
                 </div>
-                <div id="funding_reference">
-                    <h2>Funding Reference</h2>
-                    <div id="funder">
-                        <h3>Funder</h3>
-                        <p>The name of the funding provider. To receive suggestions via the API, you must enter at least the first two letters. You can also manually enter the funding provider.</p>
-                    </div>
-                    <div id="grant-number">
-                        <h3>Grant Number</h3>
-                        <p>Free text field for entering the grant number assigned by the funding provider. Optional field without restrictions.
-                             Examples: GBMF3859.01.</p>
-                    </div>
-                    <div id="grant-name">
-                        <h3>Grant Name</h3>
-                        <p>Free text field for entering the title or name of the grant. Optional field without restrictions.
-                             Examples: Socioenvironmental Monitoring of the Amazon Basin and Xingu.</p>
-                    </div>
+                <div class="section-divider"></div>
                 <div id="relatedWork">
                     <h2>Related Work</h2>
                     <div id="relation">
                         <h3>Relation Type</h3>
-                        <p>The data record is classified in the Relation Type form field. The following different relation types are available for selection.</p>
+                        <p>The data record is classified in the Relation Type form field. The following different
+                            relation types are available for selection.</p>
                         <ul>
                             <li><strong>IsCitedBy:</strong> indicates that B includes A in a citation</li>
                             <li><strong>Cites:</strong> indicates that A includes B in a citation</li>
@@ -470,23 +495,33 @@
                             <li><strong>Describes:</strong> indicates A describes B</li>
                             <li><strong>IsDescribedBy:</strong> indicates A is described by B</li>
                             <li><strong>HasMetadata:</strong> indicates resource A has additional metadata B</li>
-                            <li><strong>IsMetadataFor:</strong> indicates additional metadata A for a resource B</li>
+                            <li><strong>IsMetadataFor:</strong> indicates additional metadata A for a resource B
+                            </li>
                             <li><strong>HasVersion:</strong> indicates A has a version B</li>
                             <li><strong>IsVersionOf:</strong> indicates A is a version of B</li>
-                            <li><strong>IsNewVersionOf:</strong> indicates A is a new edition of B, where the new edition has been modified or updated</li>
+                            <li><strong>IsNewVersionOf:</strong> indicates A is a new edition of B, where the new
+                                edition has been modified or updated</li>
                             <li><strong>IsPreviousVersionOf:</strong> indicates A is a previous edition of B</li>
-                            <li><strong>IsPartOf:</strong> indicates A is a portion of B; may be used for elements of a series</li>
+                            <li><strong>IsPartOf:</strong> indicates A is a portion of B; may be used for elements
+                                of a series</li>
                             <li><strong>HasPart:</strong> indicates A includes the part B</li>
-                            <li><strong>IsPublishedIn:</strong> indicates A is published inside B, but is independent of other things published inside of B</li>
-                            <li><strong>IsReferencedBy:</strong> indicates A is used as a source of information by B</li>
-                            <li><strong>References:</strong> indicates B is used as a source of information for A</li>
-                            <li><strong>IsDocumentedBy:</strong> indicates B is documentation about/explaining A</li>
+                            <li><strong>IsPublishedIn:</strong> indicates A is published inside B, but is
+                                independent of other things published inside of B</li>
+                            <li><strong>IsReferencedBy:</strong> indicates A is used as a source of information by B
+                            </li>
+                            <li><strong>References:</strong> indicates B is used as a source of information for A
+                            </li>
+                            <li><strong>IsDocumentedBy:</strong> indicates B is documentation about/explaining A
+                            </li>
                             <li><strong>Documents:</strong> indicates A is documentation about/explaining B</li>
                             <li><strong>IsCompiledBy:</strong> indicates B is used to compile or create A</li>
-                            <li><strong>Compiles:</strong> indicates B is the result of a compile or creation event using A</li>
-                            <li><strong>IsVariantFormOf:</strong> indicates A is a variant or different form of B</li>
+                            <li><strong>Compiles:</strong> indicates B is the result of a compile or creation event
+                                using A</li>
+                            <li><strong>IsVariantFormOf:</strong> indicates A is a variant or different form of B
+                            </li>
                             <li><strong>IsOriginalFormOf:</strong> indicates A is the original form of B</li>
-                            <li><strong>IsIdenticalTo:</strong> indicates that A is identical to B, for use when there is a need to register two separate instances of the same resource</li>
+                            <li><strong>IsIdenticalTo:</strong> indicates that A is identical to B, for use when
+                                there is a need to register two separate instances of the same resource</li>
                             <li><strong>IsReviewedBy:</strong> indicates that A is reviewed by B</li>
                             <li><strong>Reviews:</strong> indicates that A is a review of B</li>
                             <li><strong>IsDerivedFrom:</strong> indicates B is a source upon which A is based</li>
@@ -507,31 +542,76 @@
                         <h3>Identifier Type</h3>
                         <p>The type of the Related Identifier.</p>
                         <ul>
-                            <li><strong>ARK:</strong> A URI designed to support long-term access to information objects. In general, ARK syntax is of the form (brackets, []. indicate optional elements).</li>
-                            <li><strong>arXiv:</strong> arXiv.org is a repository of preprints of scientific papers in the fields of mathematics, physics, astronomy, computer science, quantitative biology, statistics, and quantitative financ.</li>
-                            <li><strong>bibcode:</strong> A standardized 19-character identifier according to the syntax yyyyjjjjjvvvvmppppa.</li>
-                            <li><strong>DOI:</strong> A character string used to uniquely identify an object. A DOI name is divided into two parts, a prefix and a suffix, separated by a slash.</li>
-                            <li><strong>EAN13:</strong> A 13-digit barcoding standard that is a superset of the original 12-digit Universal Product Code (UPC) system.</li>
-                            <li><strong>EISSN:</strong> ISSN used to identify periodicals in electronic form (eISSN or e-ISSN).</li>
-                            <li><strong>Handle:</strong> This refers specifically to an ID in the Handle system operated by the Corporation for National Research Initiatives (CNRI).</li>
-                            <li><strong>IGSN:</strong> A code that uniquely identifies samples from our natural environment and related features-of-interest.</li>
-                            <li><strong>ISBN:</strong> A unique numeric book identifier. There are 2 formats: a 10-digit ISBN format and a 13-digit ISBN.</li>
-                            <li><strong>ISSN:</strong> A unique 8-digit number used to identify a print or electronic periodical publication.</li>
-                            <li><strong>ISTC:</strong> A unique “number” assigned to a textual work. An ISTC consists of 16 numbers and/or letters..</li>
-                            <li><strong>LISSN:</strong> The linking ISSN or ISSN-L enables collocation or linking among different media versions of a continuing resource.</li>
-                            <li><strong>LSID:</strong> A unique identifier for data in the Life Science domain. Format: urn:lsid:authority:namespace:identifier:revision.</li>
+                            <li><strong>ARK:</strong> A URI designed to support long-term access to information
+                                objects. In general, ARK syntax is of the form (brackets, []. indicate optional
+                                elements).</li>
+                            <li><strong>arXiv:</strong> arXiv.org is a repository of preprints of scientific papers
+                                in the fields of mathematics, physics, astronomy, computer science, quantitative
+                                biology, statistics, and quantitative financ.</li>
+                            <li><strong>bibcode:</strong> A standardized 19-character identifier according to the
+                                syntax yyyyjjjjjvvvvmppppa.</li>
+                            <li><strong>DOI:</strong> A character string used to uniquely identify an object. A DOI
+                                name is divided into two parts, a prefix and a suffix, separated by a slash.</li>
+                            <li><strong>EAN13:</strong> A 13-digit barcoding standard that is a superset of the
+                                original 12-digit Universal Product Code (UPC) system.</li>
+                            <li><strong>EISSN:</strong> ISSN used to identify periodicals in electronic form (eISSN
+                                or e-ISSN).</li>
+                            <li><strong>Handle:</strong> This refers specifically to an ID in the Handle system
+                                operated by the Corporation for National Research Initiatives (CNRI).</li>
+                            <li><strong>IGSN:</strong> A code that uniquely identifies samples from our natural
+                                environment and related features-of-interest.</li>
+                            <li><strong>ISBN:</strong> A unique numeric book identifier. There are 2 formats: a
+                                10-digit ISBN format and a 13-digit ISBN.</li>
+                            <li><strong>ISSN:</strong> A unique 8-digit number used to identify a print or
+                                electronic periodical publication.</li>
+                            <li><strong>ISTC:</strong> A unique “number” assigned to a textual work. An ISTC
+                                consists of 16 numbers and/or letters..</li>
+                            <li><strong>LISSN:</strong> The linking ISSN or ISSN-L enables collocation or linking
+                                among different media versions of a continuing resource.</li>
+                            <li><strong>LSID:</strong> A unique identifier for data in the Life Science domain.
+                                Format: urn:lsid:authority:namespace:identifier:revision.</li>
                             <li><strong>PMID:</strong> A unique number assigned to each PubMed record.</li>
-                            <li><strong>PURL:</strong> A PURL has three parts: (1) a protocol, (2) a resolver address, and (3) a name.</li>
-                            <li><strong>UPC:</strong> A barcode symbology used for tracking trade items in stores. Its most common form, the UPC-A, consists of 12 numerical digits.</li>
-                            <li><strong>URL:</strong> Also known as web address, a URL is a specific character string that constitutes a reference to a resource. The syntax is: scheme://domain:port/path?query_string#fragment_id.</li>
-                            <li><strong>URN:</strong> A unique and persistent identifier of an electronic document. The syntax is: urn:<NID>:<NSS>. The leading urn: sequence is case-insensitive, <NID> is the namespace identifier, <NSS> is the namespace-specific string.</li>
-                            <li><strong>w3id:</strong> Mostly used to publish vocabularies and ontologies. The letters ‘w3’ stand for “World Wide Web”.</li>
+                            <li><strong>PURL:</strong> A PURL has three parts: (1) a protocol, (2) a resolver
+                                address, and (3) a name.</li>
+                            <li><strong>UPC:</strong> A barcode symbology used for tracking trade items in stores.
+                                Its most common form, the UPC-A, consists of 12 numerical digits.</li>
+                            <li><strong>URL:</strong> Also known as web address, a URL is a specific character
+                                string that constitutes a reference to a resource. The syntax is:
+                                scheme://domain:port/path?query_string#fragment_id.</li>
+                            <li><strong>URN:</strong> A unique and persistent identifier of an electronic document.
+                                The syntax is: urn:<NID>:<NSS>. The leading urn: sequence is case-insensitive, <NID>
+                                            is the namespace identifier, <NSS> is the namespace-specific string.
+                            </li>
+                            <li><strong>w3id:</strong> Mostly used to publish vocabularies and ontologies. The
+                                letters ‘w3’ stand for “World Wide Web”.</li>
                         </ul>
+                    </div>
+                </div>
+                <div class="section-divider"></div>
+                <div id="funding_reference">
+                    <h2>Funding Reference</h2>
+                    <div id="funder">
+                        <h3>Funder</h3>
+                        <p>The name of the funding provider. To receive suggestions via the API, you must enter at least
+                            the first two letters. You can also manually enter the funding provider.</p>
+                    </div>
+                    <div id="grant-number">
+                        <h3>Grant Number</h3>
+                        <p>Free text field for entering the grant number assigned by the funding provider. Optional
+                            field without restrictions.
+                            Examples: GBMF3859.01.</p>
+                    </div>
+                    <div id="grant-name">
+                        <h3>Grant Name</h3>
+                        <p>Free text field for entering the title or name of the grant. Optional field without
+                            restrictions.
+                            Examples: Socioenvironmental Monitoring of the Amazon Basin and Xingu.</p>
                     </div>
                 </div>
                 <!-- Damit das scrollen besser funktioniert und unter dem letzten Selector Platz nach unten ist -->
                 <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
             </div>
+            <div class="section-divider"></div>
         </div>
     </div>
     </div>

--- a/doc/help.html
+++ b/doc/help.html
@@ -328,6 +328,8 @@
                     <div class="section-divider"></div>
                 </div>
                 <div id="mslkeywords">
+                    <h2>MSL Keywords</h2>
+                    <div id="mslkeywords">
                         <p>Please click on the Thesaurus button to the right to select keywords from the thesaurus or start typing to use the autocomplete function.
                             <div class="section-divider"></div>
                             The selectable keywords are taken from the repository of the <a target="_blank" href="https://github.com/UtrechtUniversity/msl_vocabularies">MSL vocabularies</a>.

--- a/formgroups/authors.html
+++ b/formgroups/authors.html
@@ -49,7 +49,7 @@
                 <?php echo $translations['authorORCID']; ?>
               </label>
               <div class="invalid-feedback">
-                <?php echo $translations['authorORCID_invalid']; ?>
+                <?php echo $translations['ORCID_invalid']; ?>
               </div>
             </div>
             <div class="input-group-append">

--- a/formgroups/contributors.html
+++ b/formgroups/contributors.html
@@ -69,7 +69,7 @@
                 <?php echo $translations['contributors_ORCID']; ?>
               </label>
               <div class="invalid-feedback">
-                <?php echo $translations['contributors_ORCID_invalid']; ?>
+                <?php echo $translations['ORCID_invalid']; ?>
               </div>
             </div>
             <div class="input-group-append">

--- a/formgroups/resourceInformation.html
+++ b/formgroups/resourceInformation.html
@@ -163,7 +163,7 @@
             <div class="input-group has-validation">
               <div class="form-floating">
                 <input type="text" class="form-control input-with-help input-right-no-round-corners" id="inputTitle"
-                  name="title[]" pattern="^[a-zA-ZäöüÄÖÜß 0-9]+$" required />
+                  name="title[]" pattern="^[a-zA-ZäöüÄÖÜß 0-9 .\-_()\!?]+$" required />
                 <label for="inputTitle">
                   <?php echo $translations['title']; ?>
                 </label>

--- a/formgroups/resourceInformation.html
+++ b/formgroups/resourceInformation.html
@@ -78,7 +78,7 @@
           <div class="col-12 col-sm-6 col-md-6 col-lg-2 p-1">
             <div class="input-group has-validation">
               <div class="form-floating">
-                <input type="text" inputmode="numeric" class="form-control" name="year" pattern="^[1-2]{1}[0-9]{3}$"
+                <input type="text" inputmode="numeric" class="form-control input-with-help input-right-no-round-corners" name="year" pattern="^[1-2]{1}[0-9]{3}$"
                   required id="inputPublicationYear" />
                 <label for="inputPublicationYear">
                   <?php echo $translations['publicationYear']; ?>
@@ -86,6 +86,10 @@
                 <div class="invalid-feedback">
                   <?php echo $translations['publicationYear_invalid']; ?>
                 </div>
+              </div>
+              <div class="input-group-append">
+                <span class="input-group-text"><i class="bi bi-question-circle-fill"
+                    data-help-section-id="publication-year"></i></span>
               </div>
             </div>
           </div>

--- a/formgroups/spatialtemporalcoverage.html
+++ b/formgroups/spatialtemporalcoverage.html
@@ -65,7 +65,7 @@
                             </label>
                             <div class="input-group">
                                 <input type="date" class="form-control" id="tscDateStart" name="tscDateStart[]" required>
-                                <input type="time" class="form-control input-with-help input-right-no-round-corners" id="tscTimeStart" name="tscTimeStart[]" required> 
+                                <input type="time" class="form-control input-with-help input-right-no-round-corners" id="tscTimeStart" name="tscTimeStart[]" > 
                                 <span class="input-group-text"><i class="bi bi-question-circle-fill"
                                         data-help-section-id="tsc-temporal"></i></span>
                             </div>
@@ -74,7 +74,7 @@
                             </label>
                             <div class="input-group">
                                 <input type="date" class="form-control " id="tscDateEnd" name="tscDateEnd[]" required>
-                                <input type="time" class="form-control input-with-help input-right-no-round-corners" id="tscTimeEnd" name="tscTimeEnd[]" required>
+                                <input type="time" class="form-control input-with-help input-right-no-round-corners" id="tscTimeEnd" name="tscTimeEnd[]" >
                                 <span class="input-group-text"><i class="bi bi-question-circle-fill"
                                         data-help-section-id="tsc-temporal"></i></span>
                             </div>

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -332,6 +332,8 @@ $(document).ready(function () {
 
     // Neue AuthorLine zum DOM hinzufügen
     fundingreferenceGroup.append(newFundingReferenceRow);
+    // Hilfe-Buttons in geclonter Zeile entfernen
+    deleteHelpButtonFromClonedRows(newFundingReferenceRow);
 
     // Event-Handler für RemoveButton
     newFundingReferenceRow.on("click", ".removeButton", function () {
@@ -377,6 +379,8 @@ $(document).ready(function () {
 
     // Neue LaboratoryLine zum DOM hinzufügen
     laboratoryGroup.append(newOriginatingLaboratoryRow);
+    // Hilfe-Buttons in geklonter Zeile entfernen
+    deleteHelpButtonFromClonedRows(newOriginatingLaboratoryRow);
 
     // Tagify für die neue Zeile initialisieren
     initializeTagify(newOriginatingLaboratoryRow, labData);

--- a/lang/de.php
+++ b/lang/de.php
@@ -34,7 +34,7 @@ $translations = [
     'lastname_invalid' => 'Bitte geben Sie einen Nachnamen an.',
     'firstname_invalid' => 'Bitte geben Sie einen Vornamen an.',
     'authorORCID' => 'ORCID',
-    'authorORCID_invalid' => 'Geben Sie eine gültige ORCID im Format xxxx-xxxx-xxxx-xxxx ein.',
+    'ORCID_invalid' => 'Geben Sie eine gültige ORCID ein (XXXX-XXXX-XXXX-XXX(X))',
     'affiliation_invalid' => 'Bitte geben Sie eine Zugehörigkeit an.',
 
     // Form Group Contactpersons
@@ -60,7 +60,6 @@ $translations = [
     'Organisation' => 'Organisationsname',
     'Organisation_invalid' => 'Bitte geben Sie einen gültigen Organisationsname an.',
     'contributors_ORCID' => 'Mitwirkende ORCID',
-    'contributors_ORCID_invalid' => 'Geben Sie eine gültige ORCID ein (XXXX-XXXX-XXXX-XXX(X))',
     'contributorsPersonZeile' => 'Mitwirkende Person(en)',
     'contributorsInstitutionZeile' => 'Mitwirkende Institution(en)',
 

--- a/lang/de.php
+++ b/lang/de.php
@@ -1,7 +1,7 @@
 <?php
 $translations = [
     // Allgemeines
-    'logotitle' => 'Metadata Editor 1.7',
+    'logotitle' => 'Metadata Editor 1.8',
     'choose' => 'Wählen Sie...',
     'valid' => 'Gültig',
     'PleaseChoose_invalid' => 'Bitte wählen Sie',

--- a/lang/en.php
+++ b/lang/en.php
@@ -1,7 +1,7 @@
 <?php
 $translations = [
     // Allgemeines
-    'logotitle' => 'Metadata Editor 1.7',
+    'logotitle' => 'Metadata Editor 1.8',
     'choose' => 'Choose...',
     'valid' => 'Valid',
     'PleaseChoose_invalid' => 'Please choose',

--- a/lang/en.php
+++ b/lang/en.php
@@ -34,7 +34,7 @@ $translations = [
     'lastname_invalid' => 'Please provide a lastname.',
     'firstname_invalid' => 'Please provide a firstname.',
     'authorORCID' => 'ORCID',
-    'authorORCID_invalid' => 'Enter a valid ORCID in the format xxxx-xxxx-xxxx-xxxx',
+    'ORCID_invalid' => 'Please enter a valid ORCID (XXXX-XXXX-XXXX-XXX(X))',
     'affiliation_invalid' => 'Please provide an affiliation.',
 
     // Form Group Contactpersons
@@ -48,7 +48,7 @@ $translations = [
     'website' => 'Website',
     'website_invalid' => 'Please provide a valid URL.',
 
-    // From Group Contributors
+    // From Group Originating Laboratory
     'originatingLaboratoryLabel' => 'Originating Laboratory',
     'originatingLaboratoryName' => 'Name of the originating laboratory',
     'originatingLaboratoryAffiliation' => 'Affiliation of the originating laboratory',
@@ -60,7 +60,6 @@ $translations = [
     'Organisation' => 'Organisation name',
     'Organisation_invalid' => 'Please enter a valid organization name.',
     'contributors_ORCID' => 'Contributor ORCID',
-    'contributors_ORCID_invalid' => 'Please enter a valid ORCID (XXXX-XXXX-XXXX-XXX(X))',
     'contributorsPersonZeile' => 'Contributing Person(s)',
     'contributorsInstitutionZeile' => 'Contributing Institution(s)',
 

--- a/lang/fr.php
+++ b/lang/fr.php
@@ -2,13 +2,13 @@
 ///////////////////////////////////////////////////////////////////
 // Description: French language file for the metadata editor     //
 // Authors: Matan Israel, Holger Ehrmann                         //
-// Version: 1.7                                                  //
+// Version: 1.8                                                  //
 // License: CC BY 4.0                                            //
 ///////////////////////////////////////////////////////////////////
 
 $translations = [
     // Général
-    'logotitle' => 'Éditeur de métadonnées 1.7',
+    'logotitle' => 'Éditeur de métadonnées 1.8',
     'choose' => 'Choisissez...',
     'valid' => 'Valide',
     'PleaseChoose_invalid' => 'Veuillez choisir',

--- a/lang/fr.php
+++ b/lang/fr.php
@@ -41,7 +41,7 @@ $translations = [
     'lastname_invalid' => 'Veuillez fournir un nom de famille.',
     'firstname_invalid' => 'Veuillez fournir un prénom.',
     'authorORCID' => 'ORCID',
-    'authorORCID_invalid' => 'Entrez un ORCID valide au format xxxx-xxxx-xxxx-xxxx',
+    'ORCID_invalid' => 'Veuillez entrer un ORCID valide (XXXX-XXXX-XXXX-XXX(X))',
     'affiliation_invalid' => 'Veuillez fournir une affiliation.',
 
     // Groupe de formulaire Personnes de contact
@@ -65,8 +65,7 @@ $translations = [
     'contributors_firstname_invalid' => 'Veuillez fournir le prénom du contributeur. Seules les lettres sont autorisées.',
     'Organisation' => 'Nom de l\'organisation',
     'Organisation_invalid' => 'Veuillez entrer un nom d\'organisation valide.',
-    'contributors_ORCID' => 'ORCID du contributeur',
-    'contributors_ORCID_invalid' => 'Veuillez entrer un ORCID valide (XXXX-XXXX-XXXX-XXX(X))',
+    'contributors_ORCID' => 'ORCID du contributeur', 
     'contributorsPersonZeile' => 'Personne(s) contributrice(s)',
     'contributorsInstitutionZeile' => 'Institution(s) contributrice(s)',
 


### PR DESCRIPTION
In diesem Branch wurde folgendes gefixed:

- Der Pattern in dem Eingabefeld "Title" wurde bearbeitet. #119 
- fehlende "div" in der Help Guide wurde vervollständigt.
- invalid-Nachricht für ORCID Felder vereinheitlicht. #126
- Die Hilfe-Buttons wurden in den "FG"  Originating Laboratory und Funding Reference in den geklonten Zeile entfernt. #118 
- Hilfebutton für das Feld Publication Year eingefügt. #131 
- Uhrzeiten in TSC auf optionale Felder umgestellt. #122 
- Pfadangaben relativ angegeben, Code dokumentiert nach PHPDoc-Standard #138 