### PR TITLE
Bugfix: Geklonte Zeilen für Contact Persons haben kein funktionierendes Affiliations-Feld

### DIFF
--- a/formgroups/contactpersons.html
+++ b/formgroups/contactpersons.html
@@ -5,7 +5,7 @@
   <div class="card-body">
     <div id="contactpersonsGroup">
       <div class="row" contact-person-row>
-        <!--Eingabefeld Contributors Lastname-->
+        <!-- Input field Contributors Lastname -->
         <div class="col-6 col-sm-6 col-md-4 col-lg-2 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
@@ -20,8 +20,7 @@
             </div>
           </div>
         </div>
-
-        <!--Eingabefeld Contributors Firstname-->
+        <!-- Input field Contact Person Firstname -->
         <div class="col-6 col-sm-6 col-md-4 col-lg-2 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
@@ -36,8 +35,7 @@
             </div>
           </div>
         </div>
-
-        <!--Eingabefeld Contact Persons Position-->
+        <!-- Input field Contact Persons Position -->
         <div class="col-12 col-sm-12 col-md-4 col-lg-2 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
@@ -56,8 +54,7 @@
             </div>
           </div>
         </div>
-
-        <!-- Eingabefeld Email Address/E-Mail-Adresse-->
+        <!-- Input field Email Address -->
         <div class="col-12 col-sm-12 col-md-6 col-lg-3 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
@@ -73,8 +70,7 @@
             </div>
           </div>
         </div>
-
-        <!--Eingabefeld Webseite-->
+        <!-- Input field Website -->
         <div class="col-12 col-sm-12 col-md-6 col-lg-3 p-1">
           <div class="input-group has-validation">
             <div class="form-floating">
@@ -94,8 +90,7 @@
             </div>
           </div>
         </div>
-
-        <!--Eingabefeld Affiliation-->
+        <!-- Input field Affiliation -->
         <div class="col-10 col-sm-10 col-md-11 p-1">
           <div class="input-group has-validation">
             <input type="text" class="form-control input-with-help input-right-no-round-corners" id="inputCPAffiliation"
@@ -105,8 +100,7 @@
             <input type="hidden" id="hiddenCPRorId" name="hiddenCPRorId[]" />
           </div>
         </div>
-
-        <!--Button "add Contact Person"-->
+        <!-- Button for Cloning Contact Person -->
         <div class="col-2 col-sm-10 col-md-1 p-1 d-flex justify-content-center align-items-center">
           <button type="button" class="btn btn-primary addCP" id="addCP" style="width: 36px">
             <?php echo $translations['add']; ?>

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -254,7 +254,8 @@ $(document).ready(function () {
     // Apply autocomplete to the Affiliation field
     autocompleteAffiliations(
       "inputCPAffiliation" + uniqueSuffix,
-      "hiddenCPRorId" + uniqueSuffix
+      "hiddenCPRorId" + uniqueSuffix,
+      affiliationsData
     );
 
     // Event handler for the remove button


### PR DESCRIPTION
Dieser Fix behebt das Problem #232 :

Improvements to form clarity:

* Updated comments in `formgroups/contactpersons.html` to change German labels to English and make them more descriptive. [[1]](diffhunk://#diff-2fb61cef92139b9b56f6319934602ce96c0b3377064d0ada249bc1b28ce8b92dL8-R8) [[2]](diffhunk://#diff-2fb61cef92139b9b56f6319934602ce96c0b3377064d0ada249bc1b28ce8b92dL23-R23) [[3]](diffhunk://#diff-2fb61cef92139b9b56f6319934602ce96c0b3377064d0ada249bc1b28ce8b92dL39-R38) [[4]](diffhunk://#diff-2fb61cef92139b9b56f6319934602ce96c0b3377064d0ada249bc1b28ce8b92dL59-R57) [[5]](diffhunk://#diff-2fb61cef92139b9b56f6319934602ce96c0b3377064d0ada249bc1b28ce8b92dL76-R73) [[6]](diffhunk://#diff-2fb61cef92139b9b56f6319934602ce96c0b3377064d0ada249bc1b28ce8b92dL97-R93) [[7]](diffhunk://#diff-2fb61cef92139b9b56f6319934602ce96c0b3377064d0ada249bc1b28ce8b92dL108-R103)

Enhancements to JavaScript functionality:

* Modified the `autocompleteAffiliations` function call in `js/buttons.js` to include an additional parameter `affiliationsData` for better handling of affiliation data.