### PR TITLE
Feature: Hide lab affiliation from user

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,11 +561,6 @@ JSON-Array mit Identifier-Typ-Objekten
   - Vorkommen 1-n
   - Datentyp: Zeichenkette
   - Wird gespeichert als `<contributorName>` im [DataCite-Schema 4.5](https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/contributor/) (TODO)
-- Affiliation of the originating laboratory
-  - Zugejhörigkeit des Labors, automatisch gewählt aus einer Liste je nach Laborname, oder Freitext, wenn Laborname auch Freitext.
-  - Vorkommen 1-n
-  - Datentyp: Zeichenkette
-  - Wird gespeichert als `<affiliation>` im [DataCite-Schema 4.5](https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/contributor/) (TODO)
 
 ### Contributors
 

--- a/formgroups/originatingLaboratory.html
+++ b/formgroups/originatingLaboratory.html
@@ -8,7 +8,7 @@
         <div id="group-originatinglaboratory">
             <div class="row" data-laboratory-row>
                 <!-- Input field for Laboratory Name -->
-                <div class="col-sm-6 col-md-6 col-lg-7 p-1">
+                <div class="col-sm-6 col-md-6 col-lg-7 p-1 d-none">
                     <div class="input-group has-validation">
                         <input type="text" class="form-control input-with-help input-right-no-round-corners"
                             id="input-originatinglaboratory-name" name="laboratoryName[]"

--- a/formgroups/originatingLaboratory.html
+++ b/formgroups/originatingLaboratory.html
@@ -7,7 +7,7 @@
     <div class="card-body">
         <div id="group-originatinglaboratory">
             <div class="row" data-laboratory-row>
-                <!--Eingabefeld Laboratory Name-->
+                <!-- Input field for Laboratory Name -->
                 <div class="col-sm-6 col-md-6 col-lg-7 p-1">
                     <div class="input-group has-validation">
                         <input type="text" class="form-control input-with-help input-right-no-round-corners"
@@ -18,7 +18,7 @@
                                 data-help-section-id="help-originatinglaboratory-name"></i></span>
                     </div>
                 </div>
-                <!--Eingabefeld Laboratory Affiliation-->
+                <!-- Hidden input field for Laboratory Affiliation -->
                 <div class="col-sm-5 col-md-5 col-lg-4 p-1">
                     <div class="input-group has-validation">
                         <input type="text" class="form-control input-with-help input-right-no-round-corners"
@@ -29,7 +29,7 @@
                         <input type="hidden" id="input-originatinglaboratory-rorid" name="laboratoryRorIds[]" />
                     </div>
                 </div>
-                <!--Button "add Laboratory"-->
+                <!-- Button for cloning new row -->
                 <div class="col-sm-1 col-md-1 col-lg-1 p-1 d-flex justify-content-center align-items-center">
                     <div class="align-items-center">
                         <button type="button" class="btn btn-primary addLaboratory" id="button-originatinglaboratory-add"
@@ -38,7 +38,6 @@
                         </button>
                     </div>
                 </div>
-
             </div>
         </div>
     </div>

--- a/formgroups/originatingLaboratory.html
+++ b/formgroups/originatingLaboratory.html
@@ -8,7 +8,7 @@
         <div id="group-originatinglaboratory">
             <div class="row" data-laboratory-row>
                 <!-- Input field for Laboratory Name -->
-                <div class="col-sm-6 col-md-6 col-lg-7 p-1 d-none">
+                <div class="col-sm-11 col-md-11 col-lg-11 p-1">
                     <div class="input-group has-validation">
                         <input type="text" class="form-control input-with-help input-right-no-round-corners"
                             id="input-originatinglaboratory-name" name="laboratoryName[]"
@@ -19,7 +19,7 @@
                     </div>
                 </div>
                 <!-- Hidden input field for Laboratory Affiliation -->
-                <div class="col-sm-5 col-md-5 col-lg-4 p-1">
+                <div class="col-sm-5 col-md-5 col-lg-4 p-1 d-none">
                     <div class="input-group has-validation">
                         <input type="text" class="form-control input-with-help input-right-no-round-corners"
                             id="input-originatinglaboratory-affiliation" name="laboratoryAffiliation[]"


### PR DESCRIPTION
Dieser Pull Request entfernt das **Affiliations Feld der Originating Laboratories** für die Augen der Nutzer bzw. aus der GUI.

### Documentation Updates:
* Removed outdated information about laboratory affiliation from the `README.md` file.

### Form Structure and Clarity:
* Updated the input field for the laboratory name to increase its width and changed the comment to English for better clarity.
* Changed the laboratory affiliation input field to be hidden and updated the comment to reflect this change.
* Updated the button comment to indicate it is for cloning a new row, improving clarity.
* Removed an unnecessary blank line for cleaner code formatting.