### PR TITLE
Bugfix: Autocomplete für geklonte Zeilen in Funders Reference

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -568,10 +568,7 @@ $(document).ready(function () {
    */
   $("#button-fundingreference-add").click(function () {
     var fundingreferenceGroup = $("#group-fundingreference");
-    // First row used as a template
     var firstFundingReferenceLine = fundingreferenceGroup.children().first();
-
-    // Clone the template
     var newFundingReferenceRow = firstFundingReferenceLine.clone();
 
     // Clear input fields and remove validation feedback
@@ -592,10 +589,14 @@ $(document).ready(function () {
       $(this).closest(".row").remove();
     });
 
-    // Initialize autocomplete for the new input field
-    setUpAutocompleteFunder(newFundingReferenceRow.find(".inputFunder"));
+    // Destroy autocomplete
+    const newInput = newFundingReferenceRow.find(".inputFunder");
+    if (newInput.data('ui-autocomplete')) {
+      newInput.autocomplete('destroy');
+    }
 
-    setUpAutocompleteFunder();
+    // Initialize autocomplete again for the new row
+    setUpAutocompleteFunder(newInput[0]);
   });
 
   var labData;

--- a/js/select.js
+++ b/js/select.js
@@ -94,7 +94,7 @@ $(document).ready(function () {
    * Sets up the autocomplete functionality for funder input elements.
    * @param {HTMLElement} inputElement - The input element to attach autocomplete to.
    */
-  function setUpAutocompleteFunder(inputElement) {
+  window.setUpAutocompleteFunder = function (inputElement) {
     $(inputElement)
       .autocomplete({
         source: function (request, response) {
@@ -119,7 +119,7 @@ $(document).ready(function () {
           .append("<div>" + item.name + "</div>")
           .appendTo(ul);
       };
-  }
+  };
 
   // Populate the relation dropdown field
   $.ajax({

--- a/js/select.js
+++ b/js/select.js
@@ -218,6 +218,7 @@ $(document).ready(function () {
       },
     });
   }
+});
 
 /**
  * Function to populate the dropdown menu of identifier types.

--- a/js/select.js
+++ b/js/select.js
@@ -20,9 +20,6 @@ $(document).ready(function () {
     console.error("Error loading time zones. Did you execute API call getTimezones (see documentation)?");
   });
 
-  // Initialize Chosen plugin for role selection fields
-  // $(".chosen-select").chosen({});
-
   /**
   * Populates the select field with ID input-rights-license with options created via an API call.
   * @param {boolean} isSoftware - Determines whether to retrieve licenses for software or all resource types.
@@ -221,24 +218,6 @@ $(document).ready(function () {
       },
     });
   }
-
-  // Event listener for changes in the Identifier Type select field
-  /*$(document).on("change", 'select[name^="rIdentifierType"]', function () {
-    updateValidationPattern(this);
-  });*/
-
-  // Event listener for newly added fields
-  /*$(document).on("click", ".button-relatedwork-add", function () {
-    setTimeout(function () {
-      $('select[name^="rIdentifierType"]:last').trigger("change");
-    }, 100);
-  });
-
-  // Execute initially for already existing fields
-  $('select[name^="rIdentifierType"]').each(function () {
-    updateValidationPattern(this);
-  });*/
-});
 
 /**
  * Function to populate the dropdown menu of identifier types.


### PR DESCRIPTION
Fixed #238 

Dieser Pull Request löst das Problem, dass **geklonte Funder-Zeilen keine Autocomplete-Funktion** haben.

Improvements to autocomplete functionality:

* [`js/buttons.js`](diffhunk://#diff-11827509078cde32f784e7e2265e5653cee1355115948e6de3e53fbbf44f14adL595-R599): Added logic to destroy existing autocomplete before reinitializing it for a new input field to prevent conflicts.

Code cleanup:

* [`js/buttons.js`](diffhunk://#diff-11827509078cde32f784e7e2265e5653cee1355115948e6de3e53fbbf44f14adL571-L574): Removed unnecessary comments and cleaned up the cloning process for new funding reference rows.
* [`js/select.js`](diffhunk://#diff-f23639ab50ee01de087486418e0e652284a0a5e6d05cc0698a6e85521bb46a38L23-L25): Removed unused initialization of the Chosen plugin for role selection fields.
* [`js/select.js`](diffhunk://#diff-f23639ab50ee01de087486418e0e652284a0a5e6d05cc0698a6e85521bb46a38L100-R97): Converted `setUpAutocompleteFunder` to a global function to ensure it can be accessed from other scripts. [[1]](diffhunk://#diff-f23639ab50ee01de087486418e0e652284a0a5e6d05cc0698a6e85521bb46a38L100-R97) [[2]](diffhunk://#diff-f23639ab50ee01de087486418e0e652284a0a5e6d05cc0698a6e85521bb46a38L125-R122)
* [`js/select.js`](diffhunk://#diff-f23639ab50ee01de087486418e0e652284a0a5e6d05cc0698a6e85521bb46a38L224-L240): Removed commented-out event listeners for identifier type changes and related work additions, which are no longer needed.